### PR TITLE
Compatibility with ggplot2 3.6.0

### DIFF
--- a/R/autoplot.accumulation.R
+++ b/R/autoplot.accumulation.R
@@ -28,8 +28,8 @@ autoplot.accumulation <-  function(
     ylab = NULL,
     shade_color = "grey75",
     alpha = 0.3,
-    lty = ggplot2::GeomLine$default_aes$linetype,
-    lwd = ggplot2::GeomLine$default_aes$linewidth){
+    lty = 1,
+    lwd = 0.5){
 
   # Add a site column if needed
   if (!"site" %in% colnames(object)) {

--- a/R/autoplot.profile.R
+++ b/R/autoplot.profile.R
@@ -28,8 +28,8 @@ autoplot.profile <-  function(
     ylab = "Diversity",
     shade_color = "grey75",
     alpha = 0.3,
-    lty = ggplot2::GeomLine$default_aes$linetype,
-    lwd = ggplot2::GeomLine$default_aes$linewidth){
+    lty = 1,
+    lwd = 0.5){
 
   # Add a site column if needed
   if (!"site" %in% colnames(object)) {

--- a/R/plot.species_distribution.R
+++ b/R/plot.species_distribution.R
@@ -188,8 +188,8 @@ autoplot.species_distribution <- function(
     main = NULL,
     xlab = "Rank",
     ylab = NULL,
-    pch = ggplot2::GeomPoint$default_aes$shape,
-    cex = ggplot2::GeomPoint$default_aes$size) {
+    pch = 19,
+    cex = 1.5) {
 
   # Prepare ylab
   if (is.null(ylab)) {

--- a/man/autoplot.accumulation.Rd
+++ b/man/autoplot.accumulation.Rd
@@ -12,8 +12,8 @@
   ylab = NULL,
   shade_color = "grey75",
   alpha = 0.3,
-  lty = ggplot2::GeomLine$default_aes$linetype,
-  lwd = ggplot2::GeomLine$default_aes$linewidth
+  lty = 1,
+  lwd = 0.5
 )
 }
 \arguments{

--- a/man/autoplot.profile.Rd
+++ b/man/autoplot.profile.Rd
@@ -12,8 +12,8 @@
   ylab = "Diversity",
   shade_color = "grey75",
   alpha = 0.3,
-  lty = ggplot2::GeomLine$default_aes$linetype,
-  lwd = ggplot2::GeomLine$default_aes$linewidth
+  lty = 1,
+  lwd = 0.5
 )
 }
 \arguments{

--- a/man/plot.species_distribution.Rd
+++ b/man/plot.species_distribution.Rd
@@ -27,8 +27,8 @@
   main = NULL,
   xlab = "Rank",
   ylab = NULL,
-  pch = ggplot2::GeomPoint$default_aes$shape,
-  cex = ggplot2::GeomPoint$default_aes$size
+  pch = 19,
+  cex = 1.5
 )
 }
 \arguments{


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around may 2025 and a reverse dependency test (https://github.com/tidyverse/ggplot2/pull/6287) has shown that the next version of ggplot2 is incompatible with the divent package.
This PR makes a few changes that fixes compatibility, which you can test yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`).
In the new version the `default_aes` fields are dynamic instead of static, which violates some assumptions in divent.

Best,
Teun