### PR TITLE
Restore par with on.exit()

### DIFF
--- a/R/accum_sp.R
+++ b/R/accum_sp.R
@@ -304,6 +304,7 @@ plot_map <- function(
   if (suppress_margins) {
     par_old <- graphics::par("mar")
     graphics::par(mar = c(0, 0, 2, 0))
+    on.exit(graphics::par(mar = par_old), add = TRUE)
   }
   the_image <- spatstat.explore::Smooth.ppp(
     the_ppp,
@@ -330,9 +331,6 @@ plot_map <- function(
       pch = pch,
       col = point_col
     )
-  }
-  if (suppress_margins) {
-    graphics::par("mar" = par_old)
   }
 
   # Return the image for further processing


### PR DESCRIPTION
It's not completely safe to restore `par()` manually before returning because an unexpected error in the middle of the function would prevent the restore.

``` r
f <- function() {
  opar <- par(no.readonly = TRUE)
  par(mfrow = c(2, 2))
  stop("This is an unexpected error")
  par(opar)
}

f()
#> Error in `f()`:
#> ! This is an unexpected error

plot(cars)
```

![](https://i.imgur.com/mFISLgE.png)<!-- -->

<sup>Created on 2026-07-31 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

`on.exit()` is designed to deal with this use case.

Related to https://github.com/openjournals/joss-reviews/issues/10860.