### PR TITLE
Use matrix operations where appropriate

### DIFF
--- a/R/abd_species.R
+++ b/R/abd_species.R
@@ -77,13 +77,8 @@ prob_species <- function(
   ]
   sample_sizes <- rowSums(abundances)
   # Divide each column by sample_sizes
-  return(
-    dplyr::mutate(
-      abundances,
-      dplyr::across(
-        dplyr::everything(),
-        ~ .x / sample_sizes
-      )
-    )
-  )
+  abundances <- abundances / sample_sizes
+  class(abundances) <- class(species_distribution)
+
+  return(abundances)
 }

--- a/R/accum_sp_hill.R
+++ b/R/accum_sp_hill.R
@@ -156,12 +156,7 @@ accum_sp_tsallis <- function(
       if (is.null(dim(ent_nbhood_q))) {
         ent_nbhood_q <- t(ent_nbhood_q)
       }
-      ent_q_nr_observed[, k + 1, 1] <- apply(
-        t(t(ent_nbhood_q)),
-        MARGIN = 1,
-        FUN = mean,
-        na.rm = TRUE
-      )
+      ent_q_nr_observed[, k + 1, 1] <- rowMeans(ent_nbhood_q, na.rm = TRUE)
       if (show_progress & interactive()) cli::cli_progress_update()
     }
     if (show_progress & interactive()) cli::cli_progress_done()
@@ -222,10 +217,9 @@ accum_sp_tsallis <- function(
     # all points' neighborhood for each q
     for (d in 2:length(r)) {
       # Neighbor communities of each point at distance r: 1 species per column
-      neighbor_communities <- vapply(
-        1:species_number,
-        FUN = function(i) rowSums(neighbors.array[, 1:d, i]),
-        FUN.VALUE = numeric(X$n)
+      neighbor_communities <- rowSums(
+        aperm(neighbors.array[, 1:d, , drop = FALSE], c(1, 3, 2)),
+        dims = 2
       )
       # Calculate entropy of each community and all q values
       if (correction == "none") {
@@ -311,12 +305,7 @@ accum_sp_tsallis <- function(
       if (is.null(dim(ent_nbhood_q))) {
         ent_nbhood_q <- t(ent_nbhood_q)
       }
-      ent_q_nr_observed[, d, 1] <- apply(
-        t(t(ent_nbhood_q)),
-        MARGIN = 1,
-        FUN = mean,
-        na.rm = TRUE
-      )
+      ent_q_nr_observed[, d, 1] <- rowMeans(ent_nbhood_q, na.rm = TRUE)
       if (show_progress & interactive()) cli::cli_progress_update()
     }
     if (show_progress & interactive()) cli::cli_progress_done()

--- a/R/fun_ordinariness.R
+++ b/R/fun_ordinariness.R
@@ -45,7 +45,7 @@ fun_ordinariness <- function(
   prob <- probabilities.abundances(species_distribution)[, is_species_column]
 
   # Calculate ordinariness
-  the_ordinariness <- as.matrix(prob) %*% t(similarities)
+  the_ordinariness <- tcrossprod(as.matrix(prob), similarities)
 
   if (as_numeric) {
     return(the_ordinariness)

--- a/R/profile_hill.R
+++ b/R/profile_hill.R
@@ -194,7 +194,7 @@ profile_hill.numeric <- function(
       if (show_progress & interactive()) cli::cli_progress_update()
     }
     # Recenter simulated values
-    div_means <- apply(profile_hills, 2, mean)
+    div_means <- colMeans(profile_hills)
     profile_hills <- t(
       t(profile_hills) - div_means + the_profile_hill$diversity
     )

--- a/R/profile_similarity.R
+++ b/R/profile_similarity.R
@@ -191,7 +191,7 @@ profile_similarity.numeric <- function(
       if (show_progress & interactive()) cli::cli_progress_update()
     }
     # Recenter simulated values
-    div_means <- apply(profile_similarities, 2, mean)
+    div_means <- colMeans(profile_similarities)
     profile_similarities <- t(
       t(profile_similarities) - div_means + the_profile_similarity$diversity
     )


### PR DESCRIPTION
For better performance

``` r
x <- matrix(
  runif(1e6),
  1000,
  1000
)

bench::mark(
  rowMeans(x),
  apply(x, 1, mean),
  iterations = 100
)
#> # A tibble: 2 × 6
#>   expression             min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 rowMeans(x)         2.92ms   2.98ms     334.     28.7KB       0 
#> 2 apply(x, 1, mean)   9.74ms  10.25ms      90.3    19.2MB     168.

bench::mark(
  tcrossprod(x),
  x %*% t(x),
  iterations = 100
)
#> # A tibble: 2 × 6
#>   expression         min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 tcrossprod(x)   9.39ms   12.5ms      74.2    7.63MB     24.7
#> 2 x %*% t(x)     22.42ms   26.9ms      34.9   15.26MB     28.6

df <- as.data.frame(x)
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union

bench::mark(
  df / 100,
  mutate(df, across(everything(), ~ .x / 100)),
  iterations = 100
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression                             min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                          <bch:> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 df/100                                25ms 28.2ms      33.3    8.13MB     33.3
#> 2 mutate(df, across(everything(), ~.… 42.7ms 62.4ms      15.7    14.8MB     22.6
```

<sup>Created on 2026-07-31 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Some of these changes are not completely trivial and I hope I didn't mess anything up. Please double check.

Related to https://github.com/openjournals/joss-reviews/issues/10860.